### PR TITLE
[#108] Support mocks running a background task

### DIFF
--- a/src/mock.jl
+++ b/src/mock.jl
@@ -21,7 +21,7 @@ macro mock(expr)
             local $args_var = tuple($(args...))
             local $alternate_var = Mocking.get_alternate($target, $args_var...)
             if $alternate_var !== nothing
-                $alternate_var($args_var...; $(kwargs...))
+                Base.invokelatest($alternate_var, $args_var...; $(kwargs...))
             else
                 $target($args_var...; $(kwargs...))
             end

--- a/test/async-world-ages.jl
+++ b/test/async-world-ages.jl
@@ -13,7 +13,9 @@ using Mocking
     @test bar(2) == 2
 
     # NOTE: Every top-level statement in a testset is run in a new world age.
-    intial_world_age = Base.get_world_counter()
+    if VERSION >= v"1.5"
+        intial_world_age = Base.get_world_counter()
+    end
 
     # Start a background, async task which blocks until bar() is patched, so that we
     # can test that patches to functions defined in later world ages can be called
@@ -28,7 +30,9 @@ using Mocking
     end
 
     # Make sure we're actually testing what we think we are.
-    @assert Base.get_world_counter() > intial_world_age
+    if VERSION >= v"1.5"
+        @assert Base.get_world_counter() > intial_world_age
+    end
 
     p = @patch bar(x) = 10 * x
 

--- a/test/async-world-ages.jl
+++ b/test/async-world-ages.jl
@@ -1,0 +1,44 @@
+using Test
+using Mocking
+
+# Issue #108
+@testset "patching an async task from an earlier world age" begin
+
+    function foo(x)
+        @mock bar(x)
+    end
+
+    bar(x) = x
+
+    # Before the patch
+    @test bar(2) == 2
+
+    # NOTE: Every top-level statement in a testset is run in a new world age.
+    intial_world_age = Base.get_world_counter()
+
+    # Start a background, async task which blocks until bar() is patched, so that we
+    # can test that patches to functions defined in later world ages can be called
+    # from mocks in a Task running in an earlier world age.
+    ch = Channel() do ch
+        # Block until we've started the patch
+        v1 = take!(ch)
+        # Call the (patched) foo
+        v2 = foo(v1)
+        # return the value
+        put!(ch, v2)
+    end
+
+    # Make sure we're actually testing what we think we are.
+    @assert Base.get_world_counter() > intial_world_age
+
+    p = @patch bar(x) = 10*x
+
+    apply(p) do
+        # Release the background task
+        put!(ch, 2)
+        # Fetch the task's result
+        @test take!(ch) == 20
+    end
+
+end
+

--- a/test/async-world-ages.jl
+++ b/test/async-world-ages.jl
@@ -3,7 +3,6 @@ using Mocking
 
 # Issue #108
 @testset "patching an async task from an earlier world age" begin
-
     function foo(x)
         @mock bar(x)
     end
@@ -31,7 +30,7 @@ using Mocking
     # Make sure we're actually testing what we think we are.
     @assert Base.get_world_counter() > intial_world_age
 
-    p = @patch bar(x) = 10*x
+    p = @patch bar(x) = 10 * x
 
     apply(p) do
         # Release the background task
@@ -39,6 +38,4 @@ using Mocking
         # Fetch the task's result
         @test take!(ch) == 20
     end
-
 end
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,4 +31,5 @@ using Mocking: anon_morespecific, anonymous_signature, dispatch, type_morespecif
     include("async.jl")
     include("issues.jl")
     include("activate.jl")
+    include("async-world-ages.jl")
 end


### PR DESCRIPTION
Allow patching a mocked call that is running in an older world age by changing the macro to invoke the patch through `invokelatest`.

The call was already inherently going to be a dynamic dispatch anyway, since by definition the whole point is that we want to substitute in a new function later. Invokelatest will just allow us to substitute in a function that was even _defined_ later, after this function had started running.

This doesn't add any extra overhead, nor introduce any restrictions. The only thing that it does is increase the scenarios that Mocking supports.

Fixes #108.

CC: @msagarpatel, @charnik