### PR TITLE
Fix up the scoping for the `@mock` macro.

### DIFF
--- a/src/patch.jl
+++ b/src/patch.jl
@@ -29,7 +29,7 @@ macro patch(expr::Expr)
 
     # We need to evaluate the alternate function in the context of the `@patch` macro in
     # order to support closures.
-    return esc(:(Mocking.Patch($target, $alternate)))
+    return esc(:($Patch($target, $alternate)))
 end
 
 struct PatchEnv


### PR DESCRIPTION
Previously, the macro required `Mocking` to be visible in the caller's context: It was invoking `Mocking.activated()`, for exmaple.  Now it invokes `$activated()`, which makes sure that the code uses the right version of `activated`.  Similarly for `get_alternate` and `Patch`.

Also, the macro was doing some unceessary `gensym` calls, which macro hygene can take care of automatically.