### PR TITLE
Update TagBot workflow

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -4,9 +4,25 @@ on:
     types:
       - created
   workflow_dispatch:
+    inputs:
+      lookback:
+        default: "3"
+permissions:
+  actions: read
+  checks: read
+  contents: write
+  deployments: read
+  issues: read
+  discussions: read
+  packages: read
+  pages: read
+  pull-requests: read
+  repository-projects: read
+  security-events: read
+  statuses: read
 jobs:
   TagBot:
-    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
+    if: ${{ github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot' }}
     runs-on: ubuntu-latest
     steps:
       - uses: JuliaRegistries/TagBot@v1


### PR DESCRIPTION
I noticed v0.7.8 doesn't have a tag due to the TagBot workflow being disabled. This should allow me to specify the lookback to address this.

Now the workflow matches: https://github.com/JuliaRegistries/TagBot/tree/c69d2047684bd91358772710c8727cb6f13a8be4?tab=readme-ov-file#setup