### PR TITLE
Fix tests using `macroexpand`

### DIFF
--- a/test/patch.jl
+++ b/test/patch.jl
@@ -1,14 +1,17 @@
 @testset "patch" begin
     @testset "unnamed function" begin
-        @test_throws LoadError macroexpand(@__MODULE__, :(@patch () -> nothing))
+        exception = VERSION >= v"1.7" ? ArgumentError : LoadError
+        @test_throws exception macroexpand(@__MODULE__, :(@patch () -> nothing))
     end
 
     @testset "non-function definition" begin
-        @test_throws LoadError macroexpand(@__MODULE__, :(@patch f()))
+        exception = VERSION >= v"1.7" ? ArgumentError : LoadError
+        @test_throws exception macroexpand(@__MODULE__, :(@patch f()))
     end
 
     @testset "empty-function definition" begin
-        @test_throws LoadError macroexpand(@__MODULE__, :(@patch function f end))
+        exception = VERSION >= v"1.7" ? ArgumentError : LoadError
+        @test_throws exception macroexpand(@__MODULE__, :(@patch function f end))
     end
 
     @testset "non-function definition" begin


### PR DESCRIPTION
Fixes these warnings when running the tests on Julia 1.7 and above:
```
┌ Warning: macroexpand no longer throws a LoadError so `@test_throws LoadError ...` is deprecated and passed without checking the error type!
│   caller = macro expansion at patch.jl:3 [inlined]
└ @ Core ~/.julia/dev/Mocking/test/patch.jl:3
┌ Warning: macroexpand no longer throws a LoadError so `@test_throws LoadError ...` is deprecated and passed without checking the error type!
│   caller = macro expansion at patch.jl:7 [inlined]
└ @ Core ~/.julia/dev/Mocking/test/patch.jl:7
┌ Warning: macroexpand no longer throws a LoadError so `@test_throws LoadError ...` is deprecated and passed without checking the error type!
│   caller = macro expansion at patch.jl:11 [inlined]
└ @ Core ~/.julia/dev/Mocking/test/patch.jl:11
```