### PR TITLE
Minor refactor to activate

### DIFF
--- a/src/Mocking.jl
+++ b/src/Mocking.jl
@@ -21,19 +21,17 @@ Enable `@mock` call sites to allow for calling patches instead of the original f
 """
 function activate()
     # Avoid redefining `activated` when it's already set appropriately
-    !activated() && @eval activated() = true
+    !Base.invokelatest(activated) && @eval activated() = true
     return nothing
 end
 
 function activate(f)
-    old = activated()
+    started_deactivated = !activated()
     try
         activate()
         Base.invokelatest(f)
     finally
-        if (Base.invokelatest(activated) != old)
-            @eval activated() = $old
-        end
+        started_deactivated && deactivate()
     end
 end
 
@@ -44,7 +42,7 @@ Disable `@mock` call sites to only call the original function.
 """
 function deactivate()
     # Avoid redefining `activated` when it's already set appropriately
-    activated() && @eval activated() = false
+    Base.invokelatest(activated) && @eval activated() = false
     return nothing
 end
 

--- a/test/activate.jl
+++ b/test/activate.jl
@@ -4,7 +4,7 @@
 
     # Starting with Mocking enabled.
     Mocking.activate()
-    @assert Mocking.activated()
+    @test Mocking.activated()
     Mocking.activate() do
         apply(patch) do
             @test (@mock add1(2)) == 44
@@ -16,7 +16,7 @@
     # Make sure to leave it enabled for the rest of the tests.
     try
         Mocking.deactivate()
-        @assert !Mocking.activated()
+        @test !Mocking.activated()
         Mocking.activate() do
             apply(patch) do
                 @test (@mock add1(2)) == 44


### PR DESCRIPTION
Found some minor changes I wanted to make to `activate` before I ended up deprecating the function. 

Something non-obvious is that calling `deactivate` from `activate(f)` now requires `Base.invokelatest` in order for the tests to work. I updated `activate()` to do the same for consistent behaviour.