### PR TITLE
Avoid overwrite warning using more specific method

### DIFF
--- a/src/Mocking.jl
+++ b/src/Mocking.jl
@@ -11,46 +11,42 @@ include("patch.jl")
 include("mock.jl")
 include("deprecated.jl")
 
-# Create the initial definition of `activated` which defaults Mocking to be disabled
-activated() = false
+# Create the initial definition of `activated` which defaults having Mocking be deactivated.
+# We utilize method invalidation as a feature here to allow functions using `@mock` to be
+# automatically re-compiled after Mocking was activated.
+#
+# We slightly abuse multiple-dispatch here so that we avoid having a "method definition
+# overwritten" for the first call to `Mocking.activate`. By defining a more specific method
+# we avoid the warning but can still trigger invalidation.
+_activated(::Integer) = false
 
 """
-    Mocking.activate([func])
+    Mocking.activated() -> Bool
 
-Enable `@mock` call sites to allow for calling patches instead of the original function.
+Indicates if Mocking has been activated or not via `Mocking.activate`.
+"""
+activated() = _activated(0)
+
+"""
+    Mocking.activate() -> Nothing
+
+Activates `@mock` call sites to allow for calling patches instead of the original function.
+Intended to be called within a packages `test/runtests.jl` file.
+
+!!! note
+    Calling this causes functions which use `@mock` to become invalidated and re-compiled
+    the next time they are called.
 """
 function activate()
-    # Avoid redefining `activated` when it's already set appropriately
-    !Base.invokelatest(activated) && @eval activated() = true
+    # Avoid redefining `_activated` when it's already set appropriately
+    !activated() && @eval _activated(::Int) = true
     return nothing
 end
-
-function activate(f)
-    started_deactivated = !activated()
-    try
-        activate()
-        Base.invokelatest(f)
-    finally
-        started_deactivated && deactivate()
-    end
-end
-
-"""
-    Mocking.deactivate()
-
-Disable `@mock` call sites to only call the original function.
-"""
-function deactivate()
-    # Avoid redefining `activated` when it's already set appropriately
-    Base.invokelatest(activated) && @eval activated() = false
-    return nothing
-end
-
 
 const NULLIFIED = Ref{Bool}(false)
 
 """
-    Mocking.nullify()
+    Mocking.nullify() -> Nothing
 
 Force any packages loaded after this point to treat the `@mock` macro as a no-op. Doing so
 will maximize performance by eliminating any runtime checks taking place at the `@mock` call

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -13,8 +13,9 @@ function enable(; force=false)
     depwarn(
         "`$m.enable(; force=$force)` is deprecated, use `$m.activate()` instead.",
         :enable,
+        # format trick: using this comment to force use of multiple lines
     )
-    activate()
+    return activate()
 end
 
 function activate(f)
@@ -35,6 +36,7 @@ function deactivate()
     depwarn(
         "`$m.deactivate()` is deprecated and will be removed in the future.",
         :deactivate,
+        # format trick: using this comment to force use of multiple lines
     )
 
     # Avoid redefining `_activated` when it's already set appropriately

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -10,7 +10,10 @@ end
 # qualified function name.
 function enable(; force=false)
     m = @__MODULE__
-    depwarn("`$m.enable(; force=$force)` is deprecated, use `$m.activate()` instead.", :enable)
+    depwarn(
+        "`$m.enable(; force=$force)` is deprecated, use `$m.activate()` instead.",
+        :enable,
+    )
     activate()
 end
 
@@ -29,7 +32,10 @@ end
 
 function deactivate()
     m = @__MODULE__
-    depwarn("`$m.deactivate()` is deprecated and will be removed in the future.", :deactivate)
+    depwarn(
+        "`$m.deactivate()` is deprecated and will be removed in the future.",
+        :deactivate,
+    )
 
     # Avoid redefining `_activated` when it's already set appropriately
     Base.invokelatest(activated) && @eval _activated(::Int) = false

--- a/test/activate.jl
+++ b/test/activate.jl
@@ -5,7 +5,7 @@
     # Starting with Mocking enabled.
     Mocking.activate()
     @test Mocking.activated()
-    Mocking.activate() do
+    @test_deprecated Mocking.activate() do
         apply(patch) do
             @test (@mock add1(2)) == 44
         end
@@ -15,9 +15,9 @@
     # Starting with Mocking disabled.
     # Make sure to leave it enabled for the rest of the tests.
     try
-        Mocking.deactivate()
+        @test_deprecated Mocking.deactivate()
         @test !Mocking.activated()
-        Mocking.activate() do
+        @test_deprecated Mocking.activate() do
             apply(patch) do
                 @test (@mock add1(2)) == 44
             end


### PR DESCRIPTION
As of Julia 1.10 we receive warnings like the following when running `Mocking.activate()`:
```
WARNING: Method definition activated() in module Mocking at /Users/cvogt/.julia/dev/Mocking/src/Mocking.jl:15 overwritten at /Users/cvogt/.julia/dev/Mocking/src/Mocking.jl:24.
```
As the method efinition overwrite is intentional here as we purposefully make use of invalidation to support `@mock` it would be best to silence this warning for end users.

We can use the Julia flag `--warn-overwrite=no` to do this (which is the default) but running `Pkg.test()` seems to enable this flag.

In order to silence this error message we're now avoiding overwriting an existing method and now we are instead just defining a more specific method which ends up having the same result but without the warning. We can however no longer cleanly support multiple calls to `activate`/`deactivate` as unless we want to utilize an arbitrarily deep type hierarchy. Due to this new restriction I've opted to deprecate both `deactivate` and `activate(f)` which I'm doubtful were used externally.