### PR TITLE
Specify code style with a configuration file

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,0 +1,1 @@
+style = "blue"

--- a/.github/workflows/Format.yml
+++ b/.github/workflows/Format.yml
@@ -6,6 +6,14 @@ on:
       - ".github/workflows/Format.yml"
 jobs:
   format:
+    # These permissions are needed to:
+    # - Checkout the repo
+    # - Delete old caches: https://github.com/julia-actions/cache#usage
+    # - Post formatting suggestions: https://github.com/reviewdog/action-suggester#required-permissions
+    permissions:
+      actions: write
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/Format.yml
+++ b/.github/workflows/Format.yml
@@ -1,11 +1,9 @@
-name: Format suggestions
-
+name: Format
 on:
   pull_request:
     paths:
       - "**.jl"
-      - ".github/workflows/blue_style_formatter.yml"
-
+      - ".github/workflows/Format.yml"
 jobs:
   format:
     runs-on: ubuntu-latest

--- a/.github/workflows/Format.yml
+++ b/.github/workflows/Format.yml
@@ -30,7 +30,7 @@ jobs:
         shell: julia --color=yes {0}
         run: |
           using JuliaFormatter
-          format(".", BlueStyle(); verbose=true)
+          format("."; verbose=true)
       - uses: reviewdog/action-suggester@v1
         with:
           tool_name: JuliaFormatter

--- a/src/dispatch.jl
+++ b/src/dispatch.jl
@@ -5,7 +5,6 @@
 # https://github.com/JuliaLang/julia/blob/master/doc/src/devdocs/types.md#subtyping-and-method-sorting
 type_morespecific(a, b) = ccall(:jl_type_morespecific, Bool, (Any, Any), a, b)
 
-
 """
     anonymous_signature(m::Method) -> Type{<:Tuple}
 
@@ -26,7 +25,6 @@ anonymous_signature(m::Method) = anonymous_signature(m.sig)
 anonymous_signature(sig::DataType) = Tuple{sig.parameters[2:end]...}
 anonymous_signature(sig::UnionAll) = UnionAll(sig.var, anonymous_signature(sig.body))
 
-
 """
     anon_morespecific(a::Method, b::Method) -> Bool
 
@@ -41,7 +39,6 @@ function anon_morespecific(a::Method, b::Method)
 
     return type_morespecific(a_sig, b_sig)
 end
-
 
 """
     dispatch(funcs::AbstractVector, args...) -> Tuple{Method, Any}

--- a/src/expr.jl
+++ b/src/expr.jl
@@ -2,7 +2,7 @@
 function rewrite_do(expr::Expr)
     expr.head == :do || error("expression is not a do-block")
     call, body = expr.args
-    Expr(:call, call.args[1], body, call.args[2:end]...)
+    return Expr(:call, call.args[1], body, call.args[2:end]...)
 end
 
 iskwarg(x::Any) = isa(x, Expr) && (x.head === :parameters || x.head === :kw)

--- a/test/anonymous-param.jl
+++ b/test/anonymous-param.jl
@@ -1,6 +1,6 @@
 # Issue #15
 @testset "anonymous parameter" begin
-    f(::Type{T}, n::Int) where T<:Unsigned = rand(T, n)
+    f(::Type{T}, n::Int) where {T<:Unsigned} = rand(T, n)
 
     patch = @patch f(::Type{UInt8}, n::Int) = collect(UnitRange{UInt8}(1:n))
 

--- a/test/dispatch.jl
+++ b/test/dispatch.jl
@@ -24,39 +24,39 @@
     end
 
     @testset "union all" begin
-        @test type_morespecific(Tuple{Int}, Tuple{T} where T <: Integer)
+        @test type_morespecific(Tuple{Int}, Tuple{T} where {T<:Integer})
 
-        @test !type_morespecific(Tuple{Integer}, Tuple{T} where T <: Integer)
-        @test !type_morespecific(Tuple{T} where T <: Integer, Tuple{Integer})
+        @test !type_morespecific(Tuple{Integer}, Tuple{T} where {T<:Integer})
+        @test !type_morespecific(Tuple{T} where {T<:Integer}, Tuple{Integer})
 
-        @test type_morespecific(Tuple{Type{Integer}}, Tuple{Type{T}} where T <: Integer)
-        @test !type_morespecific(Tuple{Type{T}} where T <: Integer, Tuple{Type{Integer}})
+        @test type_morespecific(Tuple{Type{Integer}}, Tuple{Type{T}} where {T<:Integer})
+        @test !type_morespecific(Tuple{Type{T}} where {T<:Integer}, Tuple{Type{Integer}})
     end
 end
 
 @testset "anonymous_signature" begin
     @testset "diagonal dispatch" begin
-        diag(::T, ::T) where T <: Integer = nothing
+        diag(::T, ::T) where {T<:Integer} = nothing
 
         diag_method = first(methods(diag, (Int, Int)))
-        diag_sig = Tuple{typeof(diag),T,T} where T <: Integer
+        diag_sig = Tuple{typeof(diag),T,T} where {T<:Integer}
         @test diag_method.sig == diag_sig
 
         @test anonymous_signature(Tuple{typeof(diag),Int,Int}) == Tuple{Int,Int}
-        @test anonymous_signature(diag_sig) == Tuple{T,T} where T <: Integer
-        @test anonymous_signature(diag_method) == Tuple{T,T} where T <:Integer
+        @test anonymous_signature(diag_sig) == Tuple{T,T} where {T<:Integer}
+        @test anonymous_signature(diag_method) == Tuple{T,T} where {T<:Integer}
     end
 
     @testset "triangular dispatch" begin
-        tri(::Vector{T}, ::S) where {T, S<:T} = nothing
+        tri(::Vector{T}, ::S) where {T,S<:T} = nothing
 
         tri_method = first(methods(tri, (Vector, Int)))
-        tri_sig = Tuple{typeof(tri),Vector{T},S} where {T, S<:T}
+        tri_sig = Tuple{typeof(tri),Vector{T},S} where {T,S<:T}
         @test tri_method.sig == tri_sig
 
         @test anonymous_signature(Tuple{typeof(tri),Vector,Int}) == Tuple{Vector,Int}
-        @test anonymous_signature(tri_sig) == Tuple{Vector{T},S} where {T, S<:T}
-        @test anonymous_signature(tri_method) == Tuple{Vector{T},S} where {T, S<:T}
+        @test anonymous_signature(tri_sig) == Tuple{Vector{T},S} where {T,S<:T}
+        @test anonymous_signature(tri_method) == Tuple{Vector{T},S} where {T,S<:T}
     end
 end
 
@@ -82,9 +82,12 @@ end
     end
 
     @testset "no arguments" begin
+        #! format: off
         funcs = [
             () -> 1
         ]
+        #! format: on
+
         m, f = dispatch(funcs)
         @test f == funcs[1]
         @test m.sig == Tuple{typeof(funcs[1])}
@@ -98,12 +101,11 @@ end
 
         m, f = dispatch(funcs, zero(Int))
         @test f == funcs[1]
-        @test m.sig == Tuple{typeof(funcs[1]), Int}
-
+        @test m.sig == Tuple{typeof(funcs[1]),Int}
 
         m, f = dispatch(funcs, zero(UInt))
         @test f == funcs[2]
-        @test m.sig == Tuple{typeof(funcs[2]), Integer}
+        @test m.sig == Tuple{typeof(funcs[2]),Integer}
     end
 
     @testset "more specific method" begin
@@ -115,11 +117,11 @@ end
 
         m, f = dispatch(funcs, zero(Int))
         @test f == funcs[1]
-        @test m.sig == Tuple{typeof(funcs[1]), Int}
+        @test m.sig == Tuple{typeof(funcs[1]),Int}
 
         m, f = dispatch(funcs, zero(UInt))
         @test f == funcs[2]
-        @test m.sig == Tuple{typeof(funcs[2]), Integer}
+        @test m.sig == Tuple{typeof(funcs[2]),Integer}
     end
 
     @testset "ambiguous" begin
@@ -131,11 +133,11 @@ end
         # In ambiguous cases the last function is preferred
         m, f = dispatch(funcs, 0)
         @test f == funcs[2]
-        @test m.sig == Tuple{typeof(funcs[2]), Integer}
+        @test m.sig == Tuple{typeof(funcs[2]),Integer}
 
         m, f = dispatch(reverse(funcs), 0)
         @test f == funcs[1]
-        @test m.sig == Tuple{typeof(funcs[1]), Integer}
+        @test m.sig == Tuple{typeof(funcs[1]),Integer}
     end
 
     @testset "optional" begin
@@ -146,15 +148,15 @@ end
 
         m, f = dispatch(funcs, 0)
         @test f == funcs[2]
-        @test m.sig == Tuple{typeof(funcs[2]), Any}
+        @test m.sig == Tuple{typeof(funcs[2]),Any}
 
         m, f = dispatch(funcs, 0, 0)
         @test f == funcs[1]
-        @test m.sig == Tuple{typeof(funcs[1]), Any, Any}
+        @test m.sig == Tuple{typeof(funcs[1]),Any,Any}
 
         m, f = dispatch(reverse(funcs), 0)
         @test f == funcs[1]
-        @test m.sig == Tuple{typeof(funcs[1]), Any}
+        @test m.sig == Tuple{typeof(funcs[1]),Any}
     end
 
     @testset "Type{T}" begin
@@ -169,7 +171,7 @@ end
 
         m, f = dispatch(funcs, Integer)
         @test f == funcs[1]
-        @test m.sig == Tuple{typeof(funcs[1]), Type{Integer}}
+        @test m.sig == Tuple{typeof(funcs[1]),Type{Integer}}
 
         m, f = dispatch(reverse(funcs), Type{Integer})
         @test f === nothing
@@ -184,10 +186,10 @@ end
 
         m, f = dispatch(funcs, Int)
         @test f == funcs[1]
-        @test m.sig == Tuple{typeof(funcs[1]), Type{Int}}
+        @test m.sig == Tuple{typeof(funcs[1]),Type{Int}}
 
         m, f = dispatch(reverse(funcs), Integer)
         @test f == funcs[2]
-        @test m.sig == Tuple{typeof(funcs[2]), Type{<:Integer}}
+        @test m.sig == Tuple{typeof(funcs[2]),Type{<:Integer}}
     end
 end

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -15,7 +15,7 @@ end
     function f end
 
     p = @patch function f(x; y=x)
-        (x, x, y, y)
+        return (x, x, y, y)
     end
 
     apply(p) do
@@ -29,7 +29,7 @@ end
     function f end
 
     p = @patch function f(x; y=:foo)
-        (x, x, y, y)
+        return (x, x, y, y)
     end
 
     apply(p) do

--- a/test/mock-in-patch.jl
+++ b/test/mock-in-patch.jl
@@ -8,9 +8,11 @@
     foo(x::Float64) = floor(x)
 
     # Patching only the function that takes a scalar
+    #! format: off
     patches = Patch[
         @patch foo(x::Float64) = ceil(x)
     ]
+    #! format: on
 
     @test (@mock foo(1.6)) == 1.0
 
@@ -36,8 +38,8 @@ end
     f(args...) = 0
 
     patches = [
-       @patch f(a::Function, b) = b
-       @patch f(b) = @mock f(() -> nothing, b)
+        @patch f(a::Function, b) = b
+        @patch f(b) = @mock f(() -> nothing, b)
     ]
 
     apply(patches) do

--- a/test/real-nested.jl
+++ b/test/real-nested.jl
@@ -1,5 +1,7 @@
 @testset "nested mock call" begin
-    readfile(filename) = (@mock isfile(filename)) ? read((@mock open(filename)), String) : ""
+    function readfile(filename)
+        return (@mock isfile(filename)) ? read((@mock open(filename)), String) : ""
+    end
 
     # Testing with both generic and anonymous functions
     patches = Patch[

--- a/test/reuse.jl
+++ b/test/reuse.jl
@@ -26,7 +26,7 @@
     end
 
     @testset "optional arguments" begin
-        f(args::T...) where T = zero(T)
+        f(args::T...) where {T} = zero(T)
 
         # Create a patch function that contains two methods: `f(x)` and `f(x, y)`
         p1 = @patch f(x, y=0) = x + y

--- a/test/targets.jl
+++ b/test/targets.jl
@@ -64,11 +64,11 @@ end
 @testset "constructor function" begin
     @test Vector() == []
 
-    p = @patch Vector() = [1,2,3]
+    p = @patch Vector() = [1, 2, 3]
     apply(p) do
         # Call alternative
-        @test (@mock Vector()) == [1,2,3]
-        @test (@mock Base.Vector()) == [1,2,3]
+        @test (@mock Vector()) == [1, 2, 3]
+        @test (@mock Base.Vector()) == [1, 2, 3]
 
         # Call original function
         @test (@mock Base.Vector{Any}()) == Any[]


### PR DESCRIPTION
Adds a `.JuliaFormatter.toml` so that the package formatting style can be applied locally. I've also applied the formatting to the entire repo.