### PR TITLE
Drop SSH key from TagBot

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -28,4 +28,3 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
Trying TagBot without setting an SSH key. Ideally will fix this issue: https://github.com/JuliaTesting/Mocking.jl/actions/runs/10060882479/job/27809542799