### PR TITLE
Reintroduce `activate(f)` and `deactivate()`

### DIFF
--- a/src/Mocking.jl
+++ b/src/Mocking.jl
@@ -50,6 +50,47 @@ function activate()
     return nothing
 end
 
+"""
+    Mocking.activate(f)
+
+
+Activate `@mock` call sites for the duration of the function `f`.
+
+!!! warning
+    This function redefines Mocking.jl internals and so can produce warnings about
+    method redefinitions. You may see the warning:
+        `WARNING: Method definition _activated($Int) at ... overwritten at ...`
+    This is expected behavior and can be safely ignored.
+    To avoid these warnings, instead use `Mocking.activate()` to activate `@mock` call
+    sites for the duration of the test suite. Alternatively, start Julia with
+    `--warn-overwrite=no` to suppress these warnings.
+"""
+function activate(f)
+    started_deactivated = !activated()
+    try
+        activate()
+        Base.invokelatest(f)
+    finally
+        started_deactivated && deactivate()
+    end
+end
+
+"""
+    Mocking.deactivate() -> Nothing
+
+Disable `@mock` call sites to only call the original function.
+
+!!! note
+    It is not usually necessary to call this function directly.
+    Instead it is recommended to simply call `Mocking.activate()` in `test/runtests.jl` to
+    activate `@mock` call sites for the duration of the test suite.
+"""
+function deactivate()
+    # Avoid redefining `_activated` when it's already set appropriately
+    Base.invokelatest(activated) && @eval _activated(::Int) = false
+    return nothing
+end
+
 const NULLIFIED = Ref{Bool}(false)
 
 """

--- a/test/activate.jl
+++ b/test/activate.jl
@@ -1,0 +1,28 @@
+@testset "activate(func) / deactivate" begin
+    add1(x) = x + 1
+    patch = @patch add1(x) = x + 42
+
+    # Starting with Mocking enabled.
+    @assert Mocking.activated()
+    Mocking.activate() do
+        apply(patch) do
+            @test (@mock add1(2)) == 44
+        end
+    end
+    @test Mocking.activated()
+
+    # Starting with Mocking disabled.
+    # Make sure to leave it enabled for the rest of the tests.
+    try
+        Mocking.deactivate()
+        @test !Mocking.activated()
+        Mocking.activate() do
+            apply(patch) do
+                @test (@mock add1(2)) == 44
+            end
+        end
+        @test !Mocking.activated()
+    finally
+        Mocking.activate()
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,4 +39,5 @@ Mocking.activate()
     include("async-scope.jl")
     include("issues.jl")
     include("async-world-ages.jl")
+    include("activate.jl")
 end


### PR DESCRIPTION
These were dropped in the initial v0.8 release
(see [PR#119](https://github.com/JuliaTesting/Mocking.jl/pull/119)) but were being used in the wild so
this PR brings them back, but with documentation
warning about the downsides of their usage.

As mentioned at https://github.com/JuliaTesting/Mocking.jl/pull/119#issuecomment-2283741833

> We use activate(f) extensively throughout our testing codebase at RAI, and removing it (as was done in the [v0.8 release](https://github.com/JuliaTesting/Mocking.jl/releases/tag/v0.8.0)) prevents us from updating Mocking.jl
>
> I think we're fine with the warnings WARNING: Method definition ... and would be happy to live with them in our tests for the convenience/safety of having the activate(f) method

(Originally added in https://github.com/JuliaTesting/Mocking.jl/pull/102)