### PR TITLE
FAQ entry on calling un-patched function inside patch

### DIFF
--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -32,3 +32,29 @@ displayed if `Mocking.activate` has been called.
 We recommend putting the call to [`Mocking.activate`](@ref activate) in your package's
 `test/runtests.jl` file after all of your import statements. The only true requirement is
 that you call  `Mocking.activate()` before the first [`apply`](@ref) call.
+
+## What if I want to call the un-patched function inside a patch?
+
+Simply call the patched function without `@mock`:
+
+```julia
+julia> f(x) = x + 1
+f (generic function with 1 method)
+
+julia> g(x) = @mock(f(x)) * 2
+g (generic function with 1 method)
+
+julia> fp = @patch f(x) = f(-x)
+Patch{typeof(f)}(f, var"##f_patch#240")
+
+julia> g(3)
+8 # = (3 + 1) * 2
+
+julia> apply(fp) do 
+           g(3)
+       end
+-4 # = (-3 + 1) * 2
+```
+
+Note that you can also use `@mock` _inside_ a patch, which can be useful when using
+multiple dispatch with patches.


### PR DESCRIPTION
I've added an FAQ entry on how to call the "un-patched" version of a function inside a patch (if you e.g. want to modify the arguments before calling a function).

@omus mentioned that using `@mock` inside a patch can be useful as well but I couldn't immediately come up with an example off the top of my head, so I just left a short note about that being possible.